### PR TITLE
fix(grantha): correct swapped retroflex/dental stop mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Grantha**: Retroflex and dental stop series were swapped. The single-letter
+  consonant tokens (`ConsonantT/Th/D/Dh/N`) are retroflex (ṭ ṭh ḍ ḍh ṇ) and the
+  doubled tokens (`ConsonantTt/Tth/Dd/Ddh/Nn`) are dental (t th d dh n) per the hub
+  convention shared with Devanagari, Kannada, etc. In `schemas/grantha.yaml` these
+  were assigned to the wrong glyphs, so `ṭa` rendered as 𑌤 (GRANTHA LETTER TA,
+  dental) and `ta` rendered as 𑌟 (GRANTHA LETTER TTA, retroflex). Round-trips still
+  succeeded because the swap was internally consistent. Added `tests/grantha_test.rs`
+  pinning the exact glyphs to prevent regression.
+
 ## [0.5.5] - 2026-02-28
 
 ### Added

--- a/schemas/grantha.yaml
+++ b/schemas/grantha.yaml
@@ -55,19 +55,19 @@ mappings:
     ConsonantJh: "𑌝"
     ConsonantNy: "𑌞"
     
-    # Retroflex stops
-    ConsonantTt: "𑌟"
-    ConsonantTth: "𑌠"
-    ConsonantDd: "𑌡"
-    ConsonantDdh: "𑌢"
-    ConsonantNn: "𑌣"
+    # Retroflex stops (single-letter tokens are retroflex per hub convention)
+    ConsonantT: "𑌟"
+    ConsonantTh: "𑌠"
+    ConsonantD: "𑌡"
+    ConsonantDh: "𑌢"
+    ConsonantN: "𑌣"
     
-    # Dental stops
-    ConsonantT: "𑌤"
-    ConsonantTh: "𑌥"
-    ConsonantD: "𑌦"
-    ConsonantDh: "𑌧"
-    ConsonantN: "𑌨"
+    # Dental stops (doubled tokens are dental per hub convention)
+    ConsonantTt: "𑌤"
+    ConsonantTth: "𑌥"
+    ConsonantDd: "𑌦"
+    ConsonantDdh: "𑌧"
+    ConsonantNn: "𑌨"
     
     # Labial stops
     ConsonantP: "𑌪"

--- a/tests/grantha_test.rs
+++ b/tests/grantha_test.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+mod grantha_tests {
+    use shlesha::Shlesha;
+
+    /// Regression test for retroflex/dental stop mapping in Grantha.
+    ///
+    /// The hub convention is that the single-letter consonant tokens
+    /// (ConsonantT/Th/D/Dh/N) are RETROFLEX (ṭ ṭh ḍ ḍh ṇ) and the doubled
+    /// tokens (ConsonantTt/Tth/Dd/Ddh/Nn) are DENTAL (t th d dh n), matching
+    /// Devanagari and every other Indic schema. The Grantha schema previously
+    /// had these two series swapped, so ṭa rendered as 𑌤 (GRANTHA LETTER TA,
+    /// dental) and ta rendered as 𑌟 (GRANTHA LETTER TTA, retroflex).
+    ///
+    /// A pure round-trip cannot catch this because the swap is internally
+    /// consistent, so this test pins the exact expected glyphs.
+    #[test]
+    fn test_grantha_retroflex_dental_stops() {
+        let t = Shlesha::new();
+
+        // Retroflex series -> Grantha retroflex letters (U+1131F..U+11323)
+        assert_eq!(t.transliterate("ṭa", "iso15919", "grantha").unwrap(), "𑌟"); // TTA
+        assert_eq!(t.transliterate("ṭha", "iso15919", "grantha").unwrap(), "𑌠"); // TTHA
+        assert_eq!(t.transliterate("ḍa", "iso15919", "grantha").unwrap(), "𑌡"); // DDA
+        assert_eq!(t.transliterate("ḍha", "iso15919", "grantha").unwrap(), "𑌢"); // DDHA
+        assert_eq!(t.transliterate("ṇa", "iso15919", "grantha").unwrap(), "𑌣"); // NNA
+
+        // Dental series -> Grantha dental letters (U+11324..U+11328)
+        assert_eq!(t.transliterate("ta", "iso15919", "grantha").unwrap(), "𑌤"); // TA
+        assert_eq!(t.transliterate("tha", "iso15919", "grantha").unwrap(), "𑌥"); // THA
+        assert_eq!(t.transliterate("da", "iso15919", "grantha").unwrap(), "𑌦"); // DA
+        assert_eq!(t.transliterate("dha", "iso15919", "grantha").unwrap(), "𑌧"); // DHA
+        assert_eq!(t.transliterate("na", "iso15919", "grantha").unwrap(), "𑌨"); // NA
+    }
+
+    #[test]
+    fn test_grantha_stops_roundtrip() {
+        let t = Shlesha::new();
+        let iso = "ṭaṭhaḍaḍhaṇatathadadhana";
+        let grantha = t.transliterate(iso, "iso15919", "grantha").unwrap();
+        let back = t.transliterate(&grantha, "grantha", "iso15919").unwrap();
+        assert_eq!(back, iso);
+    }
+}


### PR DESCRIPTION
## Summary

The Grantha schema has its **retroflex and dental stop series swapped**, so `ṭa` renders as 𑌤 (GRANTHA LETTER TA, *dental*) and `ta` renders as 𑌟 (GRANTHA LETTER TTA, *retroflex*) — and likewise for the whole ṭ/ṭh/ḍ/ḍh/ṇ ↔ t/th/d/dh/n series.

## Root cause

Per the hub convention shared with Devanagari, Kannada, etc. (verified in `schemas/iso15919.yaml` and `schemas/devanagari.yaml`):

- `ConsonantT / Th / D / Dh / N` = **retroflex** (ISO `ṭ ṭh ḍ ḍh ṇ`)
- `ConsonantTt / Tth / Dd / Ddh / Nn` = **dental** (ISO `t th d dh n`)

In `schemas/grantha.yaml`, the retroflex glyphs (𑌟 𑌠 𑌡 𑌢 𑌣) were assigned to the *dental* token names and the dental glyphs (𑌤 𑌥 𑌦 𑌧 𑌨) to the *retroflex* token names — the exact opposite of every other Indic schema.

## Why existing tests didn't catch it

The swap is internally consistent, so ISO → Grantha → ISO round-trips still succeed. This PR adds `tests/grantha_test.rs`, which pins the exact expected glyphs so a regression can't slip through again.

## Verification

Built with `maturin develop --release`:

```
ṭa  -> 𑌟  GRANTHA LETTER TTA   (was 𑌤 TA)
ṭha -> 𑌠  GRANTHA LETTER TTHA
ḍa  -> 𑌡  GRANTHA LETTER DDA
ḍha -> 𑌢  GRANTHA LETTER DDHA
ṇa  -> 𑌣  GRANTHA LETTER NNA
ta  -> 𑌤  GRANTHA LETTER TA    (was 𑌟 TTA)
tha -> 𑌥  GRANTHA LETTER THA
da  -> 𑌦  GRANTHA LETTER DA
dha -> 𑌧  GRANTHA LETTER DHA
na  -> 𑌨  GRANTHA LETTER NA
```

`taittirīya` → `𑌤𑍈𑌤𑍍𑌤𑌿𑌰𑍀𑌯` (correct dental त glyphs).

- Full existing suite: **164/164 pass**
- New `tests/grantha_test.rs`: **2/2 pass**
- ISO ↔ Grantha round-trip on the full stop series: clean

## Changes

- `schemas/grantha.yaml` — swap the retroflex/dental glyph assignments to match the hub token convention
- `tests/grantha_test.rs` — new glyph-pinning regression test
- `CHANGELOG.md` — note under `[Unreleased]`
