### PR TITLE
fix(ci): resolve clippy unnecessary_sort_by errors breaking CI

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -611,7 +611,7 @@ fn generate_roman_converter_with_template(
 ) -> Result<String, Box<dyn std::error::Error>> {
     // Sort by length (longest first) for proper matching
     let mut sorted_mappings: Vec<_> = mappings.iter().collect();
-    sorted_mappings.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    sorted_mappings.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
 
     // Prepare ALL reverse mappings for template (not just multi-character ones)
     // Note: reverse mapping means ISO → source_script, so ISO should be the key
@@ -621,7 +621,7 @@ fn generate_roman_converter_with_template(
         .collect();
 
     // Sort by length (longest first) for proper matching priority
-    reverse_mappings.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    reverse_mappings.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
 
     // Create reverse mappings with preference for canonical forms
     let mut reverse_priority_mappings: FxHashMap<&str, &str> = FxHashMap::default();
@@ -859,7 +859,7 @@ fn generate_roman_to_devanagari_converter(
 
     // Sort by length (longest first) for proper matching
     let mut sorted_mappings: Vec<_> = roman_to_deva_mappings.iter().collect();
-    sorted_mappings.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    sorted_mappings.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
 
     // Convert to template format - use the original String keys
     let mappings_for_template = &roman_to_deva_mappings;

--- a/src/modules/core/unknown_handler.rs
+++ b/src/modules/core/unknown_handler.rs
@@ -155,7 +155,7 @@ impl TransliterationResult {
 
                 // Sort tokens by position (reverse order to not affect positions)
                 let mut tokens = metadata.unknown_tokens.clone();
-                tokens.sort_by(|a, b| b.position.cmp(&a.position));
+                tokens.sort_by_key(|b| std::cmp::Reverse(b.position));
 
                 let mut result = self.output.clone();
                 for token in tokens {

--- a/src/modules/script_converter/mod.rs
+++ b/src/modules/script_converter/mod.rs
@@ -372,7 +372,7 @@ impl ScriptConverterRegistry {
         // Sort candidate keys by descending byte length so we always try the
         // longest match first (greedy / maximal munch).
         let mut candidates: Vec<(&str, &str)> = reverse.iter().map(|(&k, &v)| (k, v)).collect();
-        candidates.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        candidates.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
 
         let is_alphabet = schema.metadata.script_type == "roman"
             || schema.target == "alphabet_tokens"


### PR DESCRIPTION
## Summary

CI (`CI Quality Checks`) is currently **failing on `main`** with clippy errors, which also blocks the publish jobs. This is unrelated to any recent functional change — a newer clippy (1.96.0) started flagging descending sorts written as `sort_by(|a, b| b.key.cmp(&a.key))` under `clippy::unnecessary_sort_by`, and CI runs clippy with `-D warnings`.

Example failing run: the build script fails first with 3 errors; once that's fixed, the library surfaces 2 more of the same lint.

## Fix

Replace all five occurrences with the equivalent, clippy-clean form `sort_by_key(|b| std::cmp::Reverse(b.key))`. This preserves the exact same (descending) ordering:

- `build.rs` — 3 occurrences (length-based sorts for longest-match priority)
- `src/modules/core/unknown_handler.rs` — 1 occurrence (position sort)
- `src/modules/script_converter/mod.rs` — 1 occurrence (length-based greedy match sort)

## Verification

Ran the exact CI commands locally:

- `cargo fmt -- --check` — clean
- `cargo clippy --all-features -- -D warnings …` (full CI flag set) — clean
- `cargo test --release` — **166/166 pass**

No behavior change; ordering is identical.
